### PR TITLE
Create DBH_Workgiver.xml

### DIFF
--- a/1.5/Mods/DubsBadHygiene/Patches/DBH_Workgiver.xml
+++ b/1.5/Mods/DubsBadHygiene/Patches/DBH_Workgiver.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/WorkGiverDef[defName="DoBillsBurnPit"]/fixedBillGiverDefs</xpath>
+    <value>
+      <li>DankPyon_BurnPit</li>
+    </value>
+  </Operation>
+</Patch>


### PR DESCRIPTION
Added the MO DBH building to the DoBillsBurnPit WorkGiverDef so pawns can do the bills for it. Previously pawns would not cremate bodies using this building. 

There are other ways to do this such as creating a new WorkGiverDef but this approach seems to be more simplistic and still functional.