### PR TITLE
Proposed relabel "stonecutter's spot" -> "stonecutter's block"

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -198,7 +198,7 @@
 
 	<ThingDef ParentName="BenchBase">
 		<defName>DankPyon_StonecuttingSpot</defName>
-		<label>stonecutter's spot</label>
+		<label>stonecutter's block</label>
 		<description>A place for bashing stones to each other. Production here is slow because of the lack of tools.</description>
 		<thingClass>Building_WorkTable</thingClass>
 		<graphicData>


### PR DESCRIPTION
For coherency with the butcher's block and as in most player vocabulary, a spot is a free buildable with no physical presence in the world