### PR TITLE
Add missing gold requirement to Royal Armchair

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Furniture_Royal.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Furniture_Royal.xml
@@ -158,6 +158,9 @@
 			<li>Leathery</li>
 		</stuffCategories>
 		<costStuffCount>110</costStuffCount>
+		<costList>
+			<Gold>30</Gold>
+		</costList>
 		<pathCost>30</pathCost>
 		<fillPercent>0.40</fillPercent>
 		<designationHotKey>Misc8</designationHotKey>


### PR DESCRIPTION
Currently the royal armchair requires the exact same resources as the Vanilla armchair, which doesn't make sense.
This changes the royal armchair to correctly have an increased build requirement to line up with the other royal furnitures.