### PR TITLE
Add missing cost to Royal Throne

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Furniture_Royal.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Furniture_Royal.xml
@@ -205,6 +205,9 @@
 			<li>Metallic</li>
 		</stuffCategories>
 		<costStuffCount>125</costStuffCount>
+		<costList>
+			<DankPyon_Silk>50</DankPyon_Silk>
+		</costList>
 		<pathCost>30</pathCost>
 		<fillPercent>0.40</fillPercent>
 		<defaultPlacingRot>South</defaultPlacingRot>

--- a/1.6/Defs/ThingDefs_Buildings/Buildings_Furniture_Royal.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_Furniture_Royal.xml
@@ -205,6 +205,9 @@
 			<li>Metallic</li>
 		</stuffCategories>
 		<costStuffCount>125</costStuffCount>
+		<costList>
+			<DankPyon_Silk>50</DankPyon_Silk>
+		</costList>
 		<pathCost>30</pathCost>
 		<fillPercent>0.40</fillPercent>
 		<defaultPlacingRot>South</defaultPlacingRot>


### PR DESCRIPTION
Currently the Royal Throne costs the exact same as Vanilla's Meditation Throne, which doesn't make much sense given the aesthetic and beauty upgrade.
This pull adds silk to the cost which allows its increased beauty to be balanced with Vanilla.