### PR TITLE
fix xml defs for explorer's archive, orb and pedestal

### DIFF
--- a/1.5/Defs/ThingDefs_Buildings/Buildings_Misc_Hideouts.xml
+++ b/1.5/Defs/ThingDefs_Buildings/Buildings_Misc_Hideouts.xml
@@ -276,6 +276,10 @@ Requirements:
 		<building>
 			<paintable>false</paintable>
 		</building>
+		<researchPrerequisites>
+			<li>DankPyon_Exploration</li>
+		</researchPrerequisites>
+		<designationCategory>Misc</designationCategory>
 	</ThingDef>
 		
 	<ThingDef ParentName="DankPyon_QuestLinkables">
@@ -315,6 +319,10 @@ Requirements:
 			<glowColor>(195,200,9,0)</glowColor>
 			</li>
 		</comps>
+		<researchPrerequisites>
+			<li>DankPyon_Exploration</li>
+		</researchPrerequisites>
+		<designationCategory>Misc</designationCategory>
 	</ThingDef>
 
 	<ThingDef ParentName="DankPyon_ShelfBase">
@@ -380,5 +388,10 @@ Requirements:
 				<maxSimultaneous>8</maxSimultaneous>
 			</li>
 		</comps>
+		<researchPrerequisites>
+			<li>DankPyon_Exploration</li>
+			<li>DankPyon_RusticStorage</li>
+		</researchPrerequisites>
+		<designationCategory>Misc</designationCategory>
 	</ThingDef>
 </Defs>

--- a/1.6/Defs/ThingDefs_Buildings/Buildings_Misc_Hideouts.xml
+++ b/1.6/Defs/ThingDefs_Buildings/Buildings_Misc_Hideouts.xml
@@ -276,6 +276,10 @@ Requirements:
 		<building>
 			<paintable>false</paintable>
 		</building>
+		<researchPrerequisites>
+			<li>DankPyon_Exploration</li>
+		</researchPrerequisites>
+		<designationCategory>Misc</designationCategory>
 	</ThingDef>
 		
 	<ThingDef ParentName="DankPyon_QuestLinkables">
@@ -315,6 +319,10 @@ Requirements:
 			<glowColor>(195,200,9,0)</glowColor>
 			</li>
 		</comps>
+		<researchPrerequisites>
+			<li>DankPyon_Exploration</li>
+		</researchPrerequisites>
+		<designationCategory>Misc</designationCategory>
 	</ThingDef>
 
 	<ThingDef ParentName="DankPyon_ShelfBase">
@@ -353,7 +361,7 @@ Requirements:
 			<WorkToBuild>500</WorkToBuild>
 			<StyleDominance MayRequire="Ludeon.RimWorld.Ideology">5</StyleDominance>
 		</statBases>
-		<designationCategory Inherit="False"/>
+		<designationCategory>DankPyon_RusticStorage</designationCategory>
 		<costStuffCount>200</costStuffCount>
 		<building>
 			<maxItemsInCell>1</maxItemsInCell>
@@ -380,5 +388,10 @@ Requirements:
 				<maxSimultaneous>8</maxSimultaneous>
 			</li>
 		</comps>
+		<researchPrerequisites>
+			<li>DankPyon_Exploration</li>
+			<li>DankPyon_RusticStorage</li>
+		</researchPrerequisites>
+		<designationCategory>Misc</designationCategory>
 	</ThingDef>
 </Defs>


### PR DESCRIPTION
I was playing on 1.6 and noticed that the Explorer's Archive was not present in the build menu, but was listed in the research project 'Rustic Storage'. I did some digging and it seems the xml defs were not set right. I have fixed them for 1.5 and 1.6 

Tested as working on 1.6 at least. 