### PR TITLE
Minor capitalization fixes & Co.

### DIFF
--- a/1.6/Defs/ThingDefs_Races/Races_Alp.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Alp.xml
@@ -3,7 +3,7 @@
 
 	<ThingDef ParentName="AnimalThingBase">
 		<defName>DankPyon_Alp</defName>
-		<label>Alp</label>
+		<label>alp</label>
 		<description>A pale creature of the night, Alps invade the dreams of nearby creatures, trapping them in a nightmare and feeding on their negative emotions. Victims often report extreme signs of distress upon waking, and most travelers will not stay at a settlement without some kind of night watch due to the intense experiences often reported. Despite this, Alps tend to be easy prey with their frail bones, parchment-like skin, and decaying insides. Scholars remain unsure about the origins of these creatures, though some theorize an ancient curse may be responsible.</description>
 		<statBases>
 			<MoveSpeed>5</MoveSpeed>
@@ -170,7 +170,7 @@
 
 	<PawnKindDef ParentName="AnimalKindBase">
 		<defName>DankPyon_Alp</defName>
-		<label>Alp</label>
+		<label>alp</label>
 		<labelPlural>Ghouls</labelPlural>
 		<race>DankPyon_Alp</race>
 		<combatPower>120</combatPower>

--- a/1.6/Defs/ThingDefs_Races/Races_Animal_FarmGroup.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Animal_FarmGroup.xml
@@ -499,7 +499,7 @@
 	<!--========== Cows ==========-->
 	<ThingDef ParentName="AnimalThingBase">
 		<defName>DankPyon_Ravelder</defName>
-		<label>Ravelder</label>
+		<label>ravelder</label>
 		<description>A large domesticated ungulate, cows have been bred for millennia to produce huge amounts of milk, meat, and leather. They are exceptionally gentle creatures and will never seek revenge, no matter how many times they are harmed. Most of them are so adapted to farm life that they cannot survive in the wild.</description>
 		<statBases>
 			<MoveSpeed>3.2</MoveSpeed>
@@ -694,7 +694,7 @@
 
 	<ThingDef ParentName="AnimalThingBase">
 		<defName>DankPyon_Angus</defName>
-		<label>Angus</label>
+		<label>angus</label>
 		<description>A large domesticated ungulate, Angus have better marbling than a typical cow and are bred to produce huge amounts of milk, meat, and leather. They are exceptionally gentle creatures and will never seek revenge, no matter how many times they are harmed. Most of them are so adapted to farm life that they cannot survive in the wild.</description>
 		<statBases>
 			<MoveSpeed>3.2</MoveSpeed>

--- a/1.6/Defs/ThingDefs_Races/Races_Daer.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Daer.xml
@@ -4,7 +4,7 @@
 	<!-- =========================The Big Bad============================= -->
 	<ThingDef ParentName="AnimalThingBase">
 		<defName>DankPyon_Daer</defName>
-		<label>Daer</label>
+		<label>daer</label>
 		<description>A fabled legend amongst commonfolk, a gigantic deer with with a body of a bear... or was it a bear with the horns of the deer, nevertheless, its maws does not discriminate for when the beast hungers for prey.\n\nA daer's caracass contain majestic antlers that can be recovered by butchering, as well as providing meat that gives a mood bonus.</description>
 		<statBases>
 			<MoveSpeed>5.6</MoveSpeed>
@@ -138,7 +138,7 @@
 
 	<PawnKindDef ParentName="AnimalKindBase">
 		<defName>DankPyon_Daer</defName>
-		<label>Daer</label>
+		<label>daer</label>
 		<race>DankPyon_Daer</race>
 		<combatPower>600</combatPower>
 		<ecoSystemWeight>1</ecoSystemWeight>

--- a/1.6/Defs/ThingDefs_Races/Races_Direwolf.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Direwolf.xml
@@ -4,7 +4,7 @@
 	<!-- ========================== Warg ================================= -->
 	<ThingDef ParentName="AnimalThingBase">
 		<defName>DankPyon_Direwolf</defName>
-		<label>Direwolf</label>
+		<label>direwolf</label>
 		<description>A subspecies of the great wolf, hardened by the relentless frosts of the north. Aggressive and resolute, they hunt in well-coordinated packs. In the olden days direwolves preferred domains of cold. Lack of prey during extremely hostile winters forced them to migrate to warmer regions, where they descend upon caravans and small settlements.</description>
 		<statBases>
 			<MoveSpeed>5.2</MoveSpeed>
@@ -144,7 +144,7 @@
   
 	<PawnKindDef ParentName="AnimalKindBase">
 		<defName>DankPyon_Direwolf</defName>
-		<label>Direwolf</label>
+		<label>direwolf</label>
 		<race>DankPyon_Direwolf</race>
 		<combatPower>160</combatPower>
 		<ecoSystemWeight>0.5</ecoSystemWeight>

--- a/1.6/Defs/ThingDefs_Races/Races_Gryphon.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Gryphon.xml
@@ -4,7 +4,7 @@
 	<!-- Griffon -->
 	<ThingDef ParentName="AnimalThingBase">
 		<defName>DankPyon_Griffon</defName>
-		<label>Griffon</label>
+		<label>griffon</label>
 		<description>Griffon is a majestic creature blending the features of an eagle and a lion, embodying strength, agility, and predatory instincts, making it a formidable presence in the wilds.</description>
 		<statBases>
 			<MoveSpeed>5.8</MoveSpeed>
@@ -144,15 +144,15 @@
 
 	<PawnKindDef ParentName="AnimalKindBase">
 		<defName>DankPyon_Griffon</defName>
-		<label>Griffon</label>
-		<labelPlural>Griffons</labelPlural>
+		<label>griffon</label>
+		<labelPlural>griffons</labelPlural>
 		<race>DankPyon_Griffon</race>
 		<combatPower>500</combatPower>
 		<ecoSystemWeight>1.1</ecoSystemWeight>
 		<alternateGraphicChance>0.0</alternateGraphicChance>
 		<lifeStages>
 			<li>
-				<label>Chick</label>
+				<label>chick</label>
 				<bodyGraphicData>
 					<texPath>Things/Pawn/Animal/Griffon</texPath>
 					<drawSize>2.8</drawSize>

--- a/1.6/Defs/ThingDefs_Races/Races_Snakes.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Snakes.xml
@@ -257,7 +257,7 @@
 			<body>Snake</body>
 			<leatherDef>Leather_Rhinoceros</leatherDef><!-- Rhino is turned into heavy scale leather -->
 			<predator>true</predator>
-			<maxPreyBodySize>0.80</maxPreyBodySize>
+			<maxPreyBodySize>3</maxPreyBodySize>
 			<baseBodySize>3.55</baseBodySize>
 			<baseHungerRate>0.5</baseHungerRate>
 			<baseHealthScale>6.5</baseHealthScale>

--- a/1.6/Defs/ThingDefs_Races/Races_Snakes.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Snakes.xml
@@ -4,7 +4,7 @@
 	<!-- =========================The Big Bad============================= -->
 	<ThingDef ParentName="AnimalThingBase" Name="DankPyon_LargeCobraBase">
 		<defName>DankPyon_LargeCobraForest</defName>
-		<label>large cobra</label>
+		<label>large forest cobra</label>
 		<description>Larger than their cousins and more resilient, large cobras prove to be deadlier and more agressive when it hunts for its pray. Their bite injects toxic venom into the victim.</description>
 		<statBases>
 			<MoveSpeed>4.5</MoveSpeed>
@@ -139,7 +139,7 @@
 
 	<ThingDef ParentName="DankPyon_LargeCobraBase">
 		<defName>DankPyon_LargeCobraCave</defName>
-		<label>large cobra</label>
+		<label>large cave cobra</label>
 		<description>A venomous snake with a hood along its head that it rears when threatened. This giant creature dwells in caves and will not hesitate to protect its territory.</description>
 		<statBases>
 			<MoveSpeed>4.5</MoveSpeed>
@@ -212,7 +212,7 @@
 
 	<ThingDef ParentName="AnimalThingBase" Name="DankPyon_GiantConstrictorBase">
 		<defName>DankPyon_GiantConstrictorForest</defName>
-		<label>giant constrictor</label>
+		<label>giant forest constrictor</label>
 		<description>A primadorial snake, gigantic in size and old as the forlorn trees.</description>
 		<statBases>
 			<MoveSpeed>5.2</MoveSpeed>
@@ -579,15 +579,15 @@
 
 	<PawnKindDef ParentName="AnimalKindBase">
 		<defName>DankPyon_LindwurmForest</defName>
-		<label>lindwurm</label>
+		<label>forest lindwurm</label>
 		<race>DankPyon_LindwurmForest</race>
 		<combatPower>700</combatPower>
 		<canArriveManhunter>false</canArriveManhunter>
 		<ecoSystemWeight>1</ecoSystemWeight>
 		<lifeStages>
 			<li>
-				<label>lindwurm hatchling</label>
-				<labelPlural>lindwurm hatchlings</labelPlural>
+				<label>forest lindwurm hatchling</label>
+				<labelPlural>forest lindwurm hatchlings</labelPlural>
 				<bodyGraphicData>
 					<texPath>Things/Pawn/Animal/LindwurmForest</texPath>
 					<drawSize>2.5</drawSize>
@@ -657,7 +657,7 @@
 
 	<PawnKindDef ParentName="AnimalKindBase">
 		<defName>DankPyon_LindwurmCave</defName>
-		<label>lindwurm</label>
+		<label>cave lindwurm</label>
 		<race>DankPyon_LindwurmCave</race>
 		<defaultFactionType>DankPyon_SnakeCave_Faction</defaultFactionType>
 		<combatPower>700</combatPower>
@@ -665,8 +665,8 @@
 		<ecoSystemWeight>1</ecoSystemWeight>
 		<lifeStages>
 			<li>
-				<label>lindwurm hatchling</label>
-				<labelPlural>lindwurm hatchlings</labelPlural>
+				<label>cave lindwurm hatchling</label>
+				<labelPlural>cave lindwurm hatchlings</labelPlural>
 				<bodyGraphicData>
 					<texPath>Things/Pawn/Animal/LindwurmCave</texPath>
 					<drawSize>2.5</drawSize>

--- a/1.6/Defs/ThingDefs_Races/Races_Webknecht.xml
+++ b/1.6/Defs/ThingDefs_Races/Races_Webknecht.xml
@@ -3,7 +3,7 @@
 
 	<ThingDef ParentName="BaseInsect">
 		<defName>DankPyon_Webknecht</defName>
-		<label>Webknecht</label>
+		<label>webknecht</label>
 		<description>The Webknecht is a large arachnid that lives in sizable colonies in the dark areas of forests throughout the world of Battle Brothers. It’s there that they spin their webs between trees to trap anything from bird to deer and between.</description>
 		<statBases>
 			<MoveSpeed>5.2</MoveSpeed>
@@ -100,6 +100,7 @@
 		<race>
 			<canBePredatorPrey>false</canBePredatorPrey>
 			<predator>true</predator>
+			<maxPreyBodySize>1.80</maxPreyBodySize>			
 			<body>DankPyon_WebknechtBody</body>
 			<herdAnimal>true</herdAnimal>
 			<baseBodySize>1</baseBodySize>
@@ -167,7 +168,7 @@
     <PawnKindDef ParentName="AnimalKindBase">
 		<defName>DankPyon_Webknecht</defName>
 		<race>DankPyon_Webknecht</race>
-		<label>Webknecht</label>
+		<label>webknecht</label>
 		<combatPower>180</combatPower>
 		<ecoSystemWeight>0.2</ecoSystemWeight>
 		<wildGroupSize>


### PR DESCRIPTION
Changed some animal labels with inconsistent capitalization as well as some consistency-changes with the naming of snake-like animals (differentiation between forest & cave variants). Minor addition of <maxPreyBodySize> value to webknechts - unsure if this was intentionally not set or an oversight, but to avoid them from getting wrecked by attacking significantly larger animals, I added a pro-forma upper limit of bodySize 1.8.